### PR TITLE
Made a few useful tweeks

### DIFF
--- a/diary.sh
+++ b/diary.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 
-DIARY_DIR=$BASH_DIARY_DIR
+# This variable is set elsewhere...
+# TODO put more info in the README about this Variable
+DIARY_DIR="$BASH_DIARY_DIR"
 
 # set default dir
-if [[ $DIARY_DIR == '' ]]; then
+if [[ -z "$DIARY_DIR" ]]; then
   DIARY_DIR="$HOME/.diary/"
+fi
+
+# Important to check if the folder exists
+# and if not then to creaete it as writing to
+# it later if it doesnt exist will fail
+if [[ ! -d "$DIARY_DIR" ]]; then
+  mkdir "$DIARY_DIR"
 fi
 
 SHORTOPTS="hn:"


### PR DESCRIPTION
* Changed the BASH_DIARY_DIR to be wrapped in speech marks incase the dir has spaces in it currently it would flop
* added TODO to inform users about the location of where they should put their BASH_DIARY_DIR if they are to use it
* Changed your empty string check to be the better bash version '-z' does the same thing, basically great way of checking if a variable has been set or not (run "man test" for more info)
* Also added a quick dir checker to see if the chosen dir is available and exists with the '-d' arguement, incase the dir doesnt already exist it will create it for them!